### PR TITLE
Adding support from elixir-tools

### DIFF
--- a/lua/1-packages-definition.lua
+++ b/lua/1-packages-definition.lua
@@ -72,7 +72,8 @@ packer.startup(function(use)
 
   -- Tabs
   use {'akinsho/bufferline.nvim', tag = "*",
-    requires = 'nvim-tree/nvim-web-devicons'}
+    requires = 'nvim-tree/nvim-web-devicons'
+  }
 
   use {
     'akinsho/toggleterm.nvim',
@@ -86,6 +87,12 @@ packer.startup(function(use)
   use {
     'williamboman/mason.nvim',
     'williamboman/mason-lspconfig.nvim',
+  }
+
+  -- Elixir Tools
+  use {
+    "elixir-tools/elixir-tools.nvim", tag = "stable",
+    requires = { "nvim-lua/plenary.nvim" }
   }
 
   -- Copilot

--- a/lua/3-lsp-config.lua
+++ b/lua/3-lsp-config.lua
@@ -55,16 +55,22 @@ require('mason-lspconfig').setup {
 local lspconfig = require('lspconfig')
 local capabilities = require('cmp_nvim_lsp').default_capabilities() -- vim.lsp.protocol.make_client_capabilities()
 
--- Elixir
-lspconfig.elixirls.setup {
-  cmd = { "elixir-ls" },
-  capabilities = capabilities
-}
+require("elixir").setup({
+  nextls = {enable = false},
+  credo = {enable = true},
+  elixirls = {enable = true},
+})
 
-lspconfig.efm.setup {
-  filetypes = { 'elixir' },
-  capabilities = capabilities
-}
+-- Elixir
+-- lspconfig.elixirls.setup {
+--   cmd = { "elixir-ls" },
+--   capabilities = capabilities
+-- }
+
+-- lspconfig.efm.setup {
+--   filetypes = { 'elixir' },
+--   capabilities = capabilities
+-- }
 
 lspconfig.html.setup {
   capabilities = capabilities,

--- a/lua/8-copilot.lua
+++ b/lua/8-copilot.lua
@@ -1,4 +1,4 @@
 -- Adding custom mapping for Copilot than TAB
 vim.keymap.set('i', '<M-.>', '<Plug>(copilot-next)', { noremap = false })
 vim.keymap.set('i', '<M-,>', '<Plug>(copilot-previous)', { noremap = false })
-vim.keymap.set('i', '<C-b>', 'copilot#Accept("<CR>")', { expr = true, silent = true })
+vim.keymap.set('i', '<C-/>', "copilot#Accept('<CR>')", { expr = true, silent = true })


### PR DESCRIPTION
Removing configuration for directly use Elixir-LS and Credo, adding [Elixir tools](https://github.com/elixir-tools/elixir-tools.nvim) configuration instead.